### PR TITLE
Update manifest to version 92

### DIFF
--- a/k8s/streaming-service.yaml
+++ b/k8s/streaming-service.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: streaming
       containers:
         - name: streaming
-          image: "redbackracing/streaming_service:v3.0.0"
+          image: "redbackracing/streaming_service:v92
           imagePullPolicy: "IfNotPresent"
           env:
             - name: REDIS_URL


### PR DESCRIPTION
This PR updates the Kubernetes manifest to version 92.